### PR TITLE
Fix and improve rqlite intro

### DIFF
--- a/_posts/2015-03-26-Building-SQLite-clusters-with-rqlite.md
+++ b/_posts/2015-03-26-Building-SQLite-clusters-with-rqlite.md
@@ -2,7 +2,7 @@
 layout: post
 title: Building SQLite clusters with rqlite
 date: 2015-03-26 00:00:00
-description: Small, comprehensive, Raft based clustering middleware for SQLite databases
+description: Small, comprehensive, Raft-based clustering middleware for SQLite databases.
 author: oscillatingworks
 hn-discussion:
 tags:
@@ -13,22 +13,27 @@ tags:
 - distributed consensus
 ---
 
-Today our compass lead us into direction of [rqlite].
-It a is small, comprehensive, [Raft] based clustering middleware for [SQLite](https://sqlite.org/) databases.
-Someone could ask who the hell would need SQLite cluster but first things first.
+Today our compass lead us into direction of [`rqlite`]. It is a small, comprehensive, [Raft]-based
+clustering middleware for [SQLite](https://sqlite.org/) databases. Someone could ask
+who the hell would need SQLite cluster, but first things first.
 
-rqlite is using Raft [consensus protocol] to perform replication among SQLite database nodes.
+## Raft
+
+`rqlite` is using Raft [consensus protocol] to perform replication among SQLite database nodes.
 In short Raft is an alternative to [Paxos], which is hardly understood among population including ourselves.
-In general Raft ensures that if any state machine applies some operation as the `nth command`, no other state machine will ever apply a different `nth command`.
-This leads to consistency among distributed state machines and this is something Rqlite guaranties among SQLite nodes - consistency and partition tolerance - CP among [CAP].
+In general Raft ensures that if any state machine applies some operation as the `nth command`, no other
+state machine will ever apply a different `nth command`. This leads to consistency among distributed
+state machines and it's something `rqlite` guaranties among SQLite nodes - consistency and partition
+tolerance - CP among [CAP].
 
-Now we know what rqlite is doing and more or less how.
-But let's answer most important question - who and why would need it?
-To answer above questions lets first go back to official SQLite manifesto:
+## Use cases
 
-***SQLite is a good fit for use in cellphones, set-top boxes, televisions, game consoles,
-cameras, watches, kitchen appliances, thermostats, automobiles, machine tools, airplanes,
-remote sensors, drones, medical devices, and robots: the "internet of things"***
+Now we know more or less what `rqlite` is and how does it work. But let's answer most important question -
+who and why would need it? To answer above questions lets first go back to official SQLite manifesto:
+
+> SQLite is a good fit for use in cellphones, set-top boxes, televisions, game consoles,
+  cameras, watches, kitchen appliances, thermostats, automobiles, machine tools, airplanes,
+  remote sensors, drones, medical devices, and robots: the "internet of things"
 
 Exactly, kitchen appliances, thermostats, remote sensor, drones, robots - Internet Of Things -
 is it not what is hot right now and according to many predictions will be next big thing?
@@ -36,22 +41,30 @@ We bet it will.
 
 Currently while implementing IoT solutions you usually use some cloud based data feed and sync mechanisms,
 i.e [firebase], [relayr], but sooner or later your sensors will need to share some data/state
-only among each other, without need to synchronise it over the public network, which is
+only among each other, without need to synchronize it over the public network, which is
 faster, cheaper and more reliable.
-The biggest limitation of the above solution is a blocking nature of the Raft protocol - the save is committed if majority of nodes agree on this.
-So probably rqlite won't be good for huge sensor networks, replicating data among all of them.
-Typical use case here could be some mission critical sensor system where consistency might be the main requirement.
-For example some group of sensors (few / dozen) which work together based on some consistent state / data shared among each other.
-Data between them needs to be replicated and consistent, so others can immediately take over the responsibility from the sensor which died (warm standby).
+
+## Limitations
+
+The biggest limitation of the above solution is a blocking nature of the Raft protocol -
+the save is committed if majority of nodes agree on this.
+So probably `rqlite` won't be good for huge sensor networks, replicating data among all of
+them. Typical use case here could be some mission critical sensor system where consistency
+might be the main requirement. For example some group of sensors (few / dozen) which work
+together based on some consistent state / data shared among each other. Data between them needs
+to be replicated and consistent, so others can immediately take over the responsibility from
+the sensor which died (warm standby).
+
+## Hands on
 
 Due to its simplicity, SQLite is perfect to be run on almost any type of connected device.
-Together with rqlite it can give IoT makers solution to sync any type of data locally.
-Due to this opportunity, we strongly believe that rqlite is a very promising, still fresh but active project.
+Together with `rqlite` it can give IoT makers solution to sync any type of data locally.
+Due to this opportunity, we strongly believe that `rqlite` is a very promising, still fresh, but active project.
 Among that it is implemented in [Go], another new big thing in the world of programming languages.
-It is really hard to find good reasons not to contribute to this small but already interesting project.
+It is really hard to find good reasons not to contribute to this small, yet already interesting project.
 And we plan to do it. Let's see how far we can go. We'll keep you updated.
 
-[rqlite]: https://github.com/otoolep/rqlite
+[`rqlite`]: https://github.com/otoolep/`rqlite`
 [Raft]: https://raftconsensus.github.io/
 [consensus protocol]: http://en.wikipedia.org/wiki/Consensus_%28computer_science%29
 [Paxos]: http://en.wikipedia.org/wiki/Paxos_%28computer_science%29

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -10,9 +10,9 @@
 				<title>Building SQLite clusters with rqlite</title>
 				        
 				
-					<description>&lt;p&gt;Today our compass lead us into direction of &lt;a href=&quot;https://github.com/otoolep/rqlite&quot;&gt;rqlite&lt;/a&gt;.
-It a is small, comprehensive, &lt;a href=&quot;https://raftconsensus.github.io/&quot;&gt;Raft&lt;/a&gt; based clustering middleware for &lt;a href=&quot;https://sqlite.org/&quot;&gt;SQLite&lt;/a&gt; databases.
-Someone could ask who the hell would need SQLite cluster but first things first.&lt;/p&gt;
+					<description>&lt;p&gt;Today our compass lead us into direction of &lt;a href=&quot;https://github.com/otoolep/%60rqlite%60&quot;&gt;&lt;code&gt;rqlite&lt;/code&gt;&lt;/a&gt;. It is a small, comprehensive, &lt;a href=&quot;https://raftconsensus.github.io/&quot;&gt;Raft&lt;/a&gt;-based
+clustering middleware for &lt;a href=&quot;https://sqlite.org/&quot;&gt;SQLite&lt;/a&gt; databases. Someone could ask
+who the hell would need SQLite cluster, but first things first.&lt;/p&gt;
 </description>
 				
 				<pubDate>Thu, 26 Mar 2015 01:00:00 +0100</pubDate>

--- a/_site/index.html
+++ b/_site/index.html
@@ -88,7 +88,7 @@
 				<p class="date">Published on 26 Mar 2015 by
 					<strong>oscillatingworks</strong>
 				</p>
-				<p class="description">Small, comprehensive, Raft based clustering middleware for SQLite databases</p>
+				<p class="description">Small, comprehensive, Raft-based clustering middleware for SQLite databases.</p>
 				<br>
 			</li>
 			


### PR DESCRIPTION
Beside of typos or rewordings, some of the paragraphs were too long
and hard to read. Splitting them up and adding headers would improve
readability.
